### PR TITLE
Force deployment trigger for blog functionality

### DIFF
--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -240,3 +240,4 @@ export async function getStaticProps() {
     revalidate: 60, // Revalidate every 60 seconds for auto-publishing
   }
 }
+// Force deployment Sun Sep 28 19:38:14 UTC 2025


### PR DESCRIPTION
This PR forces a new deployment to ensure the blog functionality is properly deployed to Vercel.

The previous changes should have enabled the blog, but Vercel may not have triggered a new build. This small change will force a new deployment.