### PR TITLE
Fix Stripe payment bug: Resolve shipping information conflict

### DIFF
--- a/components/CheckoutForm_Tax.tsx
+++ b/components/CheckoutForm_Tax.tsx
@@ -36,7 +36,11 @@ export default function CheckoutForm_Tax({ intentId, email, name, onPaid, addres
     setSubmitting(true);
     setError(null);
 
-  const { error } = await stripe.confirmPayment({
+  // IMPORTANT: Shipping information is set here during payment confirmation
+    // using the publishable key. The backend does NOT set shipping when creating
+    // the PaymentIntent to avoid Stripe's security restriction that prevents
+    // updating shipping info set with a secret key using a publishable key.
+    const { error } = await stripe.confirmPayment({
       elements,
       confirmParams: {
     receipt_email: linkEmail || email,
@@ -55,6 +59,7 @@ export default function CheckoutForm_Tax({ intentId, email, name, onPaid, addres
             } : undefined,
           },
         },
+        // Shipping info is set here with publishable key (safe and correct approach)
         shipping: address?.address1 ? {
           name,
           phone: address?.phone,

--- a/pages/api/create-payment-intent-with-tax.ts
+++ b/pages/api/create-payment-intent-with-tax.ts
@@ -123,13 +123,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const effectiveRate = subtotal > 0 ? (tax / subtotal) : 0;
     const shippingAmount = shipping?.amount ? Math.round(shipping.amount) : 0;
 
+    // IMPORTANT: Do NOT set shipping here with secret key.
+    // Shipping information will be set by the frontend during payment confirmation
+    // using the publishable key via stripe.confirmPayment(). This prevents the
+    // Stripe error: "shipping information was last set with a secret key and 
+    // therefore cannot be changed with a publishable key."
     const pi = await stripe.paymentIntents.create({
       amount: total,
       currency: "usd",
       customer: stripeCustomerId,
       automatic_payment_methods: { enabled: true },
       receipt_email: customer?.email,
-      shipping: { name: customer?.name ?? "", address },
+      // shipping: REMOVED - will be set by frontend during confirmPayment
       metadata: {
         tax_calculation: calc.id,
         promo_code: promoCode || "",


### PR DESCRIPTION
## Problem
Customers were unable to complete checkout due to a Stripe payment error:

> "The shipping information on this PaymentIntent was last set with a secret key and therefore cannot be changed with a publishable key. Please use your secret key instead."

**Test case that failed:**
- Payment ID: `pi_3SDY6SIwQKMqOanf0sU3Nqac`
- Amount: $35.60
- Email: natureswaysoil@gmail.com
- Address: 533 Eden Church Rd, Snow Hill, NC 28580

## Root Cause
The backend API (`create-payment-intent-with-tax.ts`) was creating PaymentIntents with shipping information using the Stripe **SECRET key**. Then the frontend (`CheckoutForm_Tax.tsx`) attempted to update that shipping information during payment confirmation using the **PUBLISHABLE key**, which Stripe blocks for security reasons.

## Solution
Removed the `shipping` parameter from PaymentIntent creation in the backend. Shipping information is now **only** set by the frontend during `stripe.confirmPayment()` using the publishable key. This follows Stripe's security best practices.

## Changes Made

### 1. `pages/api/create-payment-intent-with-tax.ts`
- ❌ Removed `shipping: { name: customer?.name ?? "", address }` from `stripe.paymentIntents.create()`
- ✅ Added explanatory comments about the security restriction
- ✅ Shipping will now be set by frontend during payment confirmation

### 2. `components/CheckoutForm_Tax.tsx`
- ✅ Added clarifying comments that shipping is intentionally set during `confirmPayment()`
- ✅ No functional changes needed (already correctly setting shipping in `confirmParams`)

## Payment Flow (After Fix)
1. ✅ User fills out shipping form with name, email, address
2. ✅ User clicks "Update totals & payment form"
3. ✅ Backend creates PaymentIntent **without** shipping (using secret key)
4. ✅ Payment form appears with Stripe elements
5. ✅ User enters card details and clicks "Pay Now"
6. ✅ Frontend sets shipping during `confirmPayment()` (using publishable key)
7. ✅ Payment processes successfully ✨

## Testing
The fix has been validated by examining the code logic:
- Backend no longer sets shipping with secret key
- Frontend properly sets shipping with publishable key during confirmation
- No conflict occurs between key types

## Security & Best Practices
✅ Follows Stripe's security model: shipping info set with publishable key can be updated with publishable key
✅ Maintains all existing functionality
✅ No breaking changes to the payment flow

## Deployment
Once merged to `main`, Vercel will automatically deploy the fix to production.

---

**Ready to merge and deploy!** This fix will allow customers to complete their purchases successfully.