### PR TITLE
Fix: Correct ProductBundles type import to resolve build error

### DIFF
--- a/components/ProductBundles.tsx
+++ b/components/ProductBundles.tsx
@@ -1,15 +1,25 @@
 import { useState } from 'react';
 import Link from 'next/link';
-import type { Product } from '@/lib/cart';
+
+// Simplified product interface for bundle display
+interface BundleProduct {
+  id: string;
+  title: string;
+  slug: string;
+  price: number;
+  image: string;
+  category: string;
+  active: boolean;
+}
 
 interface BundleItem {
-  product: Product;
+  product: BundleProduct;
   selected: boolean;
 }
 
 interface ProductBundlesProps {
-  currentProduct: Product;
-  relatedProducts: Product[];
+  currentProduct: BundleProduct;
+  relatedProducts: BundleProduct[];
 }
 
 export default function ProductBundles({ currentProduct, relatedProducts }: ProductBundlesProps) {


### PR DESCRIPTION
## 🐛 Build Error Fix

This PR fixes the build error that occurred after merging PR #24.

### Issue
The deployment failed with error:
```
Type error: Cannot find module '@/lib/cart' or its corresponding type declarations.
```

### Solution
- Updated `ProductBundles.tsx` to use a proper `BundleProduct` interface instead of importing from non-existent `@/lib/cart`
- The component now uses a simplified product interface that matches the actual data structure passed from the product page

### Changes
- Removed incorrect import: `import type { Product } from '@/lib/cart'`
- Added proper `BundleProduct` interface definition
- Updated component props to use `BundleProduct` type

### Testing
This fix resolves the TypeScript compilation error and allows the build to complete successfully.

---
**Ready to merge immediately** ✅