### PR TITLE
Fix: Prevent Resend API client-side initialization error

### DIFF
--- a/pages/api/subscribe.ts
+++ b/pages/api/subscribe.ts
@@ -2,7 +2,28 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServiceSupabase } from '../../lib/supabase';
 import { Resend } from 'resend';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+// Lazy initialization of Resend client to ensure it only runs server-side
+// and properly reads environment variables
+let resendClient: Resend | null = null;
+
+function getResendClient(): Resend | null {
+  // Ensure this only runs on server-side
+  if (typeof window !== 'undefined') {
+    console.error('[subscribe] ERROR: Attempted to initialize Resend on client-side');
+    return null;
+  }
+  
+  if (!process.env.RESEND_API_KEY || process.env.RESEND_API_KEY === 'your_actual_resend_api_key_here') {
+    console.warn('[subscribe] RESEND_API_KEY not configured or using placeholder value');
+    return null;
+  }
+  
+  if (!resendClient) {
+    resendClient = new Resend(process.env.RESEND_API_KEY);
+  }
+  
+  return resendClient;
+}
 
 export default async function handler(
   req: NextApiRequest,
@@ -40,6 +61,16 @@ export default async function handler(
 
     // Send welcome email via Resend
     try {
+      const resend = getResendClient();
+      if (!resend) {
+        console.log('[subscribe] Email service not configured, skipping welcome email');
+        return res.status(200).json({ 
+          message: 'Successfully subscribed!',
+          success: true,
+          emailSkipped: true
+        });
+      }
+      
       await resend.emails.send({
         from: 'Nature\'s Way Soil <hello@natureswaysoil.com>',
         to: email,


### PR DESCRIPTION
## Problem
The Vercel deployment was failing with the error: `"Error: Missing API key. Pass it to the constructor new Resend("re_123")"` appearing in the browser console.

## Root Cause
In `pages/api/subscribe.ts`, the Resend client was being initialized at the module level:
```typescript
const resend = new Resend(process.env.RESEND_API_KEY);
```

This caused issues because:
1. If the environment variable wasn't available at module initialization time, it would throw an error
2. The error could potentially leak to the client-side
3. No validation for placeholder values in the API key

## Solution
Changed to lazy initialization pattern (matching the pattern used in `lib/resendClient.ts` and `lib/resend_client.ts`):
- ✅ Resend client is now initialized only when needed (lazy loading)
- ✅ Added server-side check to prevent client-side execution
- ✅ Added validation to detect placeholder API key values
- ✅ Gracefully handles missing API key by skipping email send instead of crashing
- ✅ Prevents the "Missing API key" error from appearing in browser console

## Testing
After merging and redeploying:
1. The deployment should complete successfully without errors
2. The browser console should not show any Resend-related errors
3. The subscribe functionality will work correctly when the RESEND_API_KEY is properly configured in Vercel environment variables

## Note
Make sure the `RESEND_API_KEY` environment variable is properly set in Vercel (not using the placeholder value `your_actual_resend_api_key_here`).