### PR TITLE
Fix Next.js 15 build errors

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,8 +26,6 @@ const nextConfig = {
   },
   // Enable compression
   compress: true,
-  // Enable SWC minification for better performance
-  swcMinify: true,
   async rewrites() {
     return [
       // Safety net: if Stripe is configured to POST to the site root, route it to the webhook handler

--- a/pages/api/webhooks/stripe.ts
+++ b/pages/api/webhooks/stripe.ts
@@ -25,12 +25,18 @@ const stripe = new Stripe(getSecretKey().key, {
 } as any)
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'POST') return res.status(405).end()
+  if (req.method !== 'POST') {
+    res.status(405).end()
+    return
+  }
 
   const sig = req.headers['stripe-signature'] as string
   const wh = getWebhookSecret()
   const whSecret = wh?.key as string
-  if (!whSecret) return res.status(500).send('Missing STRIPE_WEBHOOK_SECRET')
+  if (!whSecret) {
+    res.status(500).send('Missing STRIPE_WEBHOOK_SECRET')
+    return
+  }
 
   let event: Stripe.Event
   try {
@@ -38,7 +44,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     event = stripe.webhooks.constructEvent(buf, sig, whSecret)
   } catch (err: any) {
     console.error('Webhook signature verify failed:', err?.message || err)
-    return res.status(400).send(`Webhook Error: ${err.message}`)
+    res.status(400).send(`Webhook Error: ${err.message}`)
+    return
   }
 
   try {
@@ -135,9 +142,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         // ignore other events
         break
     }
-    return res.status(200).json({ received: true })
+    res.status(200).json({ received: true })
   } catch (err: any) {
     console.error('Webhook handler error:', err)
-    return res.status(500).send('Webhook handler error')
+    res.status(500).send('Webhook handler error')
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes the Next.js 15 build errors that were causing Vercel deployment failures.

## Changes Made

### 1. Fixed Stripe Webhook API Route Type Error (`pages/api/webhooks/stripe.ts`)
**Problem:** The function was returning `NextApiResponse` objects, which is incompatible with Next.js 15's expected return type of `void | Response | Promise<void | Response>`.

**Solution:** Changed the pattern from:
```typescript
return res.status(200).json({ received: true })
```
to:
```typescript
res.status(200).json({ received: true })
return
```

This ensures the function returns `void` instead of `NextApiResponse`, making it compatible with Next.js 15.

### 2. Removed Deprecated `swcMinify` Option (`next.config.js`)
**Problem:** The `swcMinify` option is deprecated in Next.js 15 and causes build warnings.

**Solution:** Removed the `swcMinify: true` line from the configuration. SWC minification is now enabled by default in Next.js 15.

## Testing
- ✅ TypeScript type errors resolved
- ✅ Configuration warnings eliminated
- ✅ Ready for Vercel deployment

## Related Issues
Fixes the build errors that appeared after the Resend fix was merged.